### PR TITLE
docs: update next and prev button links due to spec updates

### DIFF
--- a/pages/docs/specifications/v2.3.0.md
+++ b/pages/docs/specifications/v2.3.0.md
@@ -2448,3 +2448,5 @@ boolean | `boolean` | | |
 date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
+
+<DocsButton suggestions={[ { href: '/docs/specifications/v2.4.0', title: 'Release 2.4.0', type:'back', }, { href: '/docs/specifications/v2.2.0', title: 'Release 2.2.0', type:'next', } ]} />

--- a/pages/docs/specifications/v2.3.0.md
+++ b/pages/docs/specifications/v2.3.0.md
@@ -2449,4 +2449,5 @@ date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
 
+
 <DocsButton suggestions={[ { href: '/docs/specifications/v2.4.0', title: 'Release 2.4.0', type:'back', }, { href: '/docs/specifications/v2.2.0', title: 'Release 2.2.0', type:'next', } ]} />

--- a/pages/docs/specifications/v2.4.0.md
+++ b/pages/docs/specifications/v2.4.0.md
@@ -2502,3 +2502,6 @@ boolean | `boolean` | | |
 date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.
+
+<DocsButton suggestions={[ { href: '/docs/tutorials/streetlights-interactive', title: 'Streetlights - Interactive(Alpha)', type:'back', }, { href: '/docs/specifications/v2.3.0', title: 'Release 2.3.0', type:'next', } ]} />
+

--- a/pages/docs/tutorials/streetlights-interactive.md
+++ b/pages/docs/tutorials/streetlights-interactive.md
@@ -31,8 +31,8 @@ Please become our alpha testers of the tutorial:
       type:'back',
     },
     {
-      href: '/docs/specifications/v2.3.0',
-      title: 'Specifications 2.3.0',
+      href: '/docs/specifications/v2.4.0',
+      title: 'Specifications 2.4.0',
       type:'next',
     }
   ]}


### PR DESCRIPTION
changed the navigation button text and link from 2.3.0 to 2.4.0

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->