### PR TITLE
fix: broken link to message validation guide

### DIFF
--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -88,6 +88,6 @@ This indicates that your message is valid and the application recieved it correc
 In this tutorial, you learned how to connect your generated application to an MQTT broker, send messages through it, identify when an invalid message is sent to your application, and how to correct an invalid message. 
 
 ## Next steps
-Now that you've completed this tutorial, enjoy our [AsyncAPI message validation guide](pages/docs/guides/message-validation).
+Now that you've completed this tutorial, enjoy our [AsyncAPI message validation guide](https://www.asyncapi.com/docs/guides/message-validation).
 
 ---


### PR DESCRIPTION
The relative link currently leads to a 404 instead of the described guide. I couldn't easily figure out whether you generally use absolute URLs or if there is some link generation step in between but some other pages seem to use absolute URLs too so I went with that.