### PR TITLE
docs: fix title in adding-bindings.md

### DIFF
--- a/pages/docs/concepts/asyncapi-document/adding-bindings.md
+++ b/pages/docs/concepts/asyncapi-document/adding-bindings.md
@@ -1,5 +1,5 @@
 ---
-title: Adding Bindings
+title: Adding bindings
 weight: 260
 ---
 


### PR DESCRIPTION
The page title for this bindings doc is inconsistent, as we observe sentence capitalization in nav titles. 

<img width="600" alt="Screenshot 2023-12-12 at 12 55 41 PM" src="https://github.com/asyncapi/website/assets/19964402/a6ee6f0a-f824-4af3-b749-9e9a7b35c4c5">
