### PR TITLE
docs: fix page weights for displaying correct nav order

### DIFF
--- a/pages/docs/tutorials/kafka/index.md
+++ b/pages/docs/tutorials/kafka/index.md
@@ -1,7 +1,7 @@
 ---
 title: Create AsyncAPI document for applications consuming from Kafka
 description: A tutorial teaching how to configure an AsyncAPI document for Kafka messages.
-weight: 20
+weight: 220
 ---
 
 ## Introduction


### PR DESCRIPTION
I just realized I accidentally merged some mistakes to docs in this week, so this PR is to address these issues. 