### PR TITLE
fix: memory leak and layout shift in finance page (#5114)

### DIFF
--- a/pages/finance.tsx
+++ b/pages/finance.tsx
@@ -16,24 +16,6 @@ import Container from '../components/layout/Container';
  * bar chart, success stories, and contact us components.
  */
 export default function FinancialSummary() {
-  const [windowWidth, setWindowWidth] = useState<number>(0);
-
-  const handleResizeRef = useRef<() => void>(null!);
-
-  handleResizeRef.current = () => {
-    setWindowWidth(window.innerWidth);
-  };
-
-  // Handle window resize event to update the window width state value for responsive design purposes
-  useEffect(() => {
-    handleResizeRef.current!();
-    window.addEventListener('resize', handleResizeRef.current!);
-
-    return () => {
-      window.removeEventListener('resize', handleResizeRef.current!);
-    };
-  }, []);
-
   const title = 'AsyncAPI Finance Summary';
   const description = 'Financial Summary of AsyncAPI';
 
@@ -53,7 +35,13 @@ export default function FinancialSummary() {
     </>
   );
 
-  const shouldUseContainer = windowWidth > 1700;
-
-  return <div>{shouldUseContainer ? <Container wide>{renderComponents()}</Container> : renderComponents()}</div>;
+  return (
+    <Container
+      fluid
+      className='min-[1701px]:mx-auto min-[1701px]:w-full min-[1701px]:max-w-screen-xl'
+      padding='none'
+    >
+      {renderComponents()}
+    </Container>
+  );
 }

--- a/pages/finance.tsx
+++ b/pages/finance.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import AsyncAPISummary from '../components/FinancialSummary/AsyncAPISummary';
 import BarChartComponent from '../components/FinancialSummary/BarChartComponent';
@@ -36,11 +36,7 @@ export default function FinancialSummary() {
   );
 
   return (
-    <Container
-      fluid
-      className='min-[1701px]:mx-auto min-[1701px]:w-full min-[1701px]:max-w-screen-xl'
-      padding='none'
-    >
+    <Container fluid className='min-[1701px]:mx-auto min-[1701px]:w-full min-[1701px]:max-w-screen-xl' padding='none'>
       {renderComponents()}
     </Container>
   );


### PR DESCRIPTION
Fixes #5114. Removed unstable resize listener in finance page and moved layout logic to CSS to prevent memory leaks and CLS. Also addressed a hydration mismatch in BarChartComponent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chart now renders with fixed dimensions (800x400) only after mount; a loading placeholder displays until ready.
  * Page layout simplified to a consistent fluid container, removing dynamic viewport-based responsive branching.
  * Responsive width state and resize-driven logic removed for simpler layout handling.

* **UI**
  * Explicit chart container height and an Expenses section shown on larger screens; placeholders used while initializing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->