### PR TITLE
Make dashboard generation resilient to GitHub rate limits

### DIFF
--- a/.github/workflows/regenerate-meetings-and-videos.yml
+++ b/.github/workflows/regenerate-meetings-and-videos.yml
@@ -34,8 +34,14 @@ jobs:
         - name: Install dependencies
           run: npm install
 
-        - name: Regenerate
-          run: npm run generate:meetings && npm run generate:videos && npm run generate:dashboard
+        - name: Regenerate meetings and videos
+          run: npm run generate:meetings && npm run generate:videos
+
+        - name: Regenerate dashboard data
+          run: npm run generate:dashboard
+
+        - name: Verify dashboard data changed or exists
+          run: test -s dashboard.json
 
         - name: Create Pull Request with new meetings.json, newsroom-videos.json and dashboard.json version
           uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # use 4.2.4 https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.4
@@ -44,7 +50,7 @@ jobs:
             commit-message: 'chore: update meetings.json, newsrooom_videos.json and dashboard.json'
             committer: asyncapi-bot <info@asyncapi.io>
             author: asyncapi-bot <info@asyncapi.io>
-            title: 'chore: update meetings.json and newsrooom_videos.json'
+            title: 'chore: update meetings.json, newsroom_videos.json and dashboard.json'
             branch: update-meetings/${{ github.sha }}
         - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
           name: Report workflow run status to Slack

--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -20,6 +20,44 @@ import { Queries } from './issue-queries';
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = dirname(currentFilePath);
+const RATE_LIMIT_RETRY_BUFFER_MS = 10_000;
+const RATE_LIMIT_LOW_WATERMARK = Number(process.env.DASHBOARD_RATE_LIMIT_LOW_WATERMARK || 100);
+const RATE_LIMIT_MAX_WAIT_MS = Number(process.env.DASHBOARD_RATE_LIMIT_MAX_WAIT_MS || 15 * 60 * 1000);
+
+type RateLimit = {
+  cost: number;
+  limit: number;
+  remaining: number;
+  resetAt: string;
+};
+
+async function waitForRateLimitReset(rateLimit: RateLimit): Promise<void> {
+  if (rateLimit.remaining > RATE_LIMIT_LOW_WATERMARK) {
+    return;
+  }
+
+  const resetAt = new Date(rateLimit.resetAt).valueOf();
+  const waitMs = Math.max(0, resetAt - Date.now() + RATE_LIMIT_RETRY_BUFFER_MS);
+
+  logger.warn(
+    'GitHub GraphQL rateLimit is low\n' +
+      `cost = ${rateLimit.cost}\n` +
+      `limit = ${rateLimit.limit}\n` +
+      `remaining = ${rateLimit.remaining}\n` +
+      `resetAt = ${rateLimit.resetAt}\n` +
+      `waitMs = ${waitMs}`
+  );
+
+  if (waitMs > RATE_LIMIT_MAX_WAIT_MS) {
+    throw new Error(
+      `GitHub GraphQL rate limit reset wait (${waitMs}ms) exceeds max wait (${RATE_LIMIT_MAX_WAIT_MS}ms)`
+    );
+  }
+
+  if (waitMs > 0) {
+    await pause(waitMs);
+  }
+}
 
 /**
  * Calculates the number of full months elapsed since the provided date.
@@ -85,15 +123,7 @@ async function getDiscussions(
       }
     });
 
-    if (result.rateLimit.remaining <= 100) {
-      logger.warn(
-        'GitHub GraphQL rateLimit \n' +
-          `cost = ${result.rateLimit.cost}\n` +
-          `limit = ${result.rateLimit.limit}\n` +
-          `remaining = ${result.rateLimit.remaining}\n` +
-          `resetAt = ${result.rateLimit.resetAt}`
-      );
-    }
+    await waitForRateLimitReset(result.rateLimit);
 
     await pause(500);
 
@@ -135,6 +165,8 @@ async function getDiscussionByID(isPR: boolean, id: string): Promise<PullRequest
         authorization: `token ${token}`
       }
     });
+
+    await waitForRateLimitReset(result.rateLimit);
 
     return result;
   } catch (error) {
@@ -294,21 +326,16 @@ async function mapGoodFirstIssues(issues: GoodFirstIssues[]): Promise<MappedIssu
  * @returns A promise that resolves once the data has been successfully written.
  */
 async function start(writePath: string): Promise<void> {
-  try {
-    const issues = (await getDiscussions(Queries.hotDiscussionsIssues, 20)) as HotDiscussionsIssuesNode[];
-    const PRs = (await getDiscussions(Queries.hotDiscussionsPullRequests, 20)) as HotDiscussionsPullRequestsNode[];
-    const rawGoodFirstIssues: GoodFirstIssues[] = await getDiscussions(Queries.goodFirstIssues, 20);
-    const discussions = issues.concat(PRs);
-    const [hotDiscussions, goodFirstIssues] = await Promise.all([
-      getHotDiscussions(discussions),
-      mapGoodFirstIssues(rawGoodFirstIssues)
-    ]);
+  const issues = (await getDiscussions(Queries.hotDiscussionsIssues, 20)) as HotDiscussionsIssuesNode[];
+  const PRs = (await getDiscussions(Queries.hotDiscussionsPullRequests, 20)) as HotDiscussionsPullRequestsNode[];
+  const rawGoodFirstIssues: GoodFirstIssues[] = await getDiscussions(Queries.goodFirstIssues, 20);
+  const discussions = issues.concat(PRs);
+  const [hotDiscussions, goodFirstIssues] = await Promise.all([
+    getHotDiscussions(discussions),
+    mapGoodFirstIssues(rawGoodFirstIssues)
+  ]);
 
-    await writeToFile({ hotDiscussions, goodFirstIssues }, writePath);
-  } catch (error) {
-    logger.error('There were some issues parsing data from github.');
-    logger.error(error);
-  }
+  await writeToFile({ hotDiscussions, goodFirstIssues }, writePath);
 }
 
 /* istanbul ignore next */
@@ -324,5 +351,6 @@ export {
   mapGoodFirstIssues,
   processHotDiscussions,
   start,
+  waitForRateLimitReset,
   writeToFile
 };

--- a/types/scripts/dashboard.ts
+++ b/types/scripts/dashboard.ts
@@ -73,6 +73,7 @@ export interface PullRequestById {
     timelineItems: TimelineItems;
     comments: Comments;
   } & BasicIssueOrPR;
+  rateLimit: RateLimit;
 }
 
 export interface IssueById {
@@ -82,6 +83,7 @@ export interface IssueById {
     comments: Comments;
     reviews: Reviews;
   } & BasicIssueOrPR;
+  rateLimit: RateLimit;
 }
 
 export interface GoodFirstIssues extends BasicIssueOrPR {}


### PR DESCRIPTION
Closes #5333

## Summary
- Add rate-limit low-watermark handling for dashboard GraphQL queries and detailed logging before waiting for reset.
- Stop swallowing dashboard generation failures so the scheduled workflow fails instead of opening a PR without updated `dashboard.json`.
- Split dashboard generation into its own workflow step and verify `dashboard.json` exists before creating the update PR.
- Update the create-PR title to include dashboard data.

## Validation
- `npm run generate:dashboard` fails fast locally without `GITHUB_TOKEN`, confirming dashboard errors now propagate.
- `npx tsc --noEmit --project tsconfig.json --pretty false` was attempted; the repo currently reports pre-existing unrelated TypeScript errors in components/tests, and the dashboard type error introduced by this change was fixed by adding `rateLimit` to the by-id response types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GitHub API rate-limit handling in dashboard generation

* **Chores**
  * Updated workflow to include dashboard and video files in pull requests
  * Improved error handling in dashboard build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->