### PR TITLE
fix: make tools workflow deterministic for same set of tools

### DIFF
--- a/scripts/tools/combine-tools.ts
+++ b/scripts/tools/combine-tools.ts
@@ -296,12 +296,18 @@ const combineTools = async (
     }
 
     fs.writeFileSync(toolsPath, JSON.stringify(finalTools, null, 2));
+
+    // Sort language and technology tags by name for deterministic output,
+    // since new tags are appended in encounter order which varies between runs.
+    const sortedLanguages = [...languageList].sort((a, b) => a.name.localeCompare(b.name));
+    const sortedTechnologies = [...technologyList].sort((a, b) => a.name.localeCompare(b.name));
+
     fs.writeFileSync(
       tagsPath,
       JSON.stringify(
         {
-          languages: languageList,
-          technologies: technologyList
+          languages: sortedLanguages,
+          technologies: sortedTechnologies
         },
         null,
         2

--- a/scripts/tools/extract-tools-github.ts
+++ b/scripts/tools/extract-tools-github.ts
@@ -62,8 +62,16 @@ export async function getData(): Promise<ToolsData> {
     incompleteResult = data.incomplete_results || false;
   }
 
-  result.data.items = [...allItems];
+  const items = [...allItems] as ToolsData;
 
-  return result.data.items;
+  // Sort items by repository full_name for deterministic ordering,
+  // since the GitHub Code Search API returns results in non-deterministic order.
+  items.sort((a: any, b: any) => {
+    const repoA = a.repository?.full_name || '';
+    const repoB = b.repository?.full_name || '';
+
+    return repoA.localeCompare(repoB) || (a.path || '').localeCompare(b.path || '');
+  });
+
+  return items;
 }
-

--- a/scripts/tools/tools-object.ts
+++ b/scripts/tools/tools-object.ts
@@ -45,7 +45,7 @@ async function createToolObject(
   repoDescription = '',
   isAsyncAPIrepo: boolean = false
 ) {
-  const resultantObject = {
+  const resultObject = {
     title: toolFile.title,
     description: toolFile?.description ? toolFile.description : repoDescription,
     links: {
@@ -59,10 +59,10 @@ async function createToolObject(
     }
   };
 
-  return resultantObject;
+  return resultObject;
 }
 
-// Each result obtained from the Github API call will be tested and verified
+// Each result obtained from the GitHub API call will be tested and verified
 // using the defined JSON schema, categorising each tool inside their defined categories
 // and creating a JSON tool object in which all the tools are listed in defined
 // categories order, which is then updated in `automated-tools.json` file.
@@ -144,6 +144,14 @@ async function convertTools(data: ToolsData) {
         }
       })
     );
+
+    // Sort each category's toolsList by title for deterministic output,
+    // since Promise.all resolves tools concurrently in non-deterministic order.
+    for (const category of Object.keys(finalToolsObject)) {
+      finalToolsObject[category].toolsList.sort((a: any, b: any) =>
+        (a.title || '').localeCompare(b.title || '')
+      );
+    }
 
     return finalToolsObject;
   } catch (err: unknown) {

--- a/tests/build-tools.test.ts
+++ b/tests/build-tools.test.ts
@@ -148,4 +148,21 @@ describe('buildTools', () => {
       buildToolsManual(automatedToolsPath, invalidManualPath, toolsPath, tagsPath)
     ).rejects.toThrow('Manual tools file not found');
   });
+
+  it('should produce sorted tags in deterministic order', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockExtractData });
+    await buildTools(automatedToolsPath, manualToolsPath, toolsPath, tagsPath);
+
+    const tagsContent = JSON.parse(fs.readFileSync(tagsPath, 'utf8'));
+
+    // Verify languages are sorted alphabetically by name
+    const languageNames = tagsContent.languages.map((l: { name: string }) => l.name);
+
+    expect(languageNames).toEqual([...languageNames].sort());
+
+    // Verify technologies are sorted alphabetically by name
+    const technologyNames = tagsContent.technologies.map((t: { name: string }) => t.name);
+
+    expect(technologyNames).toEqual([...technologyNames].sort());
+  });
 });

--- a/tests/build-tools.test.ts
+++ b/tests/build-tools.test.ts
@@ -158,11 +158,11 @@ describe('buildTools', () => {
     // Verify languages are sorted alphabetically by name
     const languageNames = tagsContent.languages.map((l: { name: string }) => l.name);
 
-    expect(languageNames).toEqual([...languageNames].sort());
+    expect(languageNames).toEqual([...languageNames].sort((a, b) => a.localeCompare(b)));
 
     // Verify technologies are sorted alphabetically by name
     const technologyNames = tagsContent.technologies.map((t: { name: string }) => t.name);
 
-    expect(technologyNames).toEqual([...technologyNames].sort());
+    expect(technologyNames).toEqual([...technologyNames].sort((a, b) => a.localeCompare(b)));
   });
 });

--- a/tests/fixtures/buildToolsData.ts
+++ b/tests/fixtures/buildToolsData.ts
@@ -4,8 +4,8 @@ const tagsData = {
     { name: 'Python', color: 'bg-[#3572A5]', borderColor: 'border-[#3572A5]' }
   ],
   technologies: [
-    { name: 'React', color: 'bg-[#61dafb]', borderColor: 'border-[#61dafb]' },
-    { name: 'Node.js', color: 'bg-[#68a063]', borderColor: 'border-[#68a063]' }
+    { name: 'Node.js', color: 'bg-[#68a063]', borderColor: 'border-[#68a063]' },
+    { name: 'React', color: 'bg-[#61dafb]', borderColor: 'border-[#61dafb]' }
   ]
 };
 

--- a/tests/fixtures/combineToolsData.ts
+++ b/tests/fixtures/combineToolsData.ts
@@ -1,4 +1,4 @@
-import type { Category, ToolIgnoreEntry } from '../../types/scripts/tools';
+import type { Category, ToolIgnoreEntry } from '../types/scripts/tools';
 
 const expectedDataT1 = {
   languages: [
@@ -15,14 +15,14 @@ const expectedDataT1 = {
   ],
   technologies: [
     {
-      name: 'Node.js',
-      color: 'bg-[#61d0f2]',
-      borderColor: 'border-[#40ccf7]'
-    },
-    {
       name: 'Flask',
       color: 'bg-[#000000]',
       borderColor: 'border-[#FFFFFF]'
+    },
+    {
+      name: 'Node.js',
+      color: 'bg-[#61d0f2]',
+      borderColor: 'border-[#40ccf7]'
     }
   ]
 };

--- a/tests/tools/extract-tools-github.test.ts
+++ b/tests/tools/extract-tools-github.test.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-import { logger } from '../../scripts/helpers/logger';
-import { getData } from '../../scripts/tools/extract-tools-github';
+import { logger } from '../scripts/helpers/logger';
+import { getData } from '../scripts/tools/extract-tools-github';
 
-jest.mock('../../scripts/helpers/logger', () => ({
+jest.mock('../scripts/helpers/logger', () => ({
   logger: { info: jest.fn() }
 }));
 
@@ -99,5 +99,63 @@ describe('getData', () => {
     await expect(getData()).rejects.toThrow('GITHUB_TOKEN environment variable is required');
 
     process.env.GITHUB_TOKEN = 'mockToken';
+  });
+
+  it('should return items sorted by repository full_name', async () => {
+    const unsortedItems = [
+      {
+        name: '.asyncapi-tool',
+        path: '.asyncapi-tool',
+        repository: {
+          full_name: 'z-project/tool',
+          html_url: 'https://github.com/z-project/tool',
+          description: 'Z project',
+          owner: { login: 'z-project' }
+        }
+      },
+      {
+        name: '.asyncapi-tool',
+        path: '.asyncapi-tool',
+        repository: {
+          full_name: 'a-project/tool',
+          html_url: 'https://github.com/a-project/tool',
+          description: 'A project',
+          owner: { login: 'a-project' }
+        }
+      },
+      {
+        name: '.asyncapi-tool',
+        path: '.asyncapi-tool',
+        repository: {
+          full_name: 'm-project/tool',
+          html_url: 'https://github.com/m-project/tool',
+          description: 'M project',
+          owner: { login: 'm-project' }
+        }
+      }
+    ];
+
+    const mockData = {
+      data: {
+        items: unsortedItems,
+        total_count: 3
+      }
+    };
+
+    const apiBaseUrl = 'https://api.github.com/search/code?q=filename:.asyncapi-tool&per_page=50&page=1';
+    const headers = {
+      accept: 'application/vnd.github.text-match+json',
+      authorization: `token ${process.env.GITHUB_TOKEN}`
+    };
+
+    mockedAxios.get.mockResolvedValue(mockData);
+
+    const result = await getData();
+
+    expect(result).toHaveLength(3);
+    expect(result[0].repository.full_name).toBe('a-project/tool');
+    expect(result[1].repository.full_name).toBe('m-project/tool');
+    expect(result[2].repository.full_name).toBe('z-project/tool');
+    expect(axios.get).toHaveBeenCalledWith(apiBaseUrl, { headers });
   });
 });

--- a/tests/tools/tools-object.test.ts
+++ b/tests/tools/tools-object.test.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 
 import type { AsyncAPITool, Category } from '@/types/scripts/tools';
 
-import { logger } from '../../scripts/helpers/logger';
-import { convertTools, createToolObject } from '../../scripts/tools/tools-object';
+import { logger } from '../scripts/helpers/logger';
+import { convertTools, createToolObject } from '../scripts/tools/tools-object';
 import {
   createExpectedToolObject,
   createMalformedYAML,
@@ -11,12 +11,12 @@ import {
   createToolFileContent
 } from '../helper/toolsObjectData';
 
-jest.mock('../../scripts/helpers/logger.ts', () => ({
+jest.mock('../scripts/helpers/logger.ts', () => ({
   logger: { warn: jest.fn(), error: jest.fn() }
 }));
 
 jest.mock('axios');
-jest.mock('../../scripts/tools/categorylist', () => ({
+jest.mock('../scripts/tools/categorylist', () => ({
   categoryList: [
     { name: 'Category1', tag: 'Category1', description: 'Description for Category1' },
     { name: 'Others', tag: 'Others', description: 'Other tools category' }
@@ -227,5 +227,44 @@ describe('Tools Object', () => {
     // the tool should only be added once to that category
     expect(result.Category1.toolsList).toHaveLength(1);
     expect(result.Category1.toolsList[0].title).toBe('Duplicate Category Tool');
+  });
+
+  it('should sort tools in each category alphabetically by title', async () => {
+    const toolContentZ = {
+      title: 'Z Tool',
+      description: 'Z Tool Description',
+      links: { repoUrl: 'https://github.com/asyncapi/z-tool' },
+      filters: { categories: ['Category1' as unknown as Category] }
+    };
+    const toolContentA = {
+      title: 'A Tool',
+      description: 'A Tool Description',
+      links: { repoUrl: 'https://github.com/asyncapi/a-tool' },
+      filters: { categories: ['Category1' as unknown as Category] }
+    };
+    const toolContentM = {
+      title: 'M Tool',
+      description: 'M Tool Description',
+      links: { repoUrl: 'https://github.com/asyncapi/m-tool' },
+      filters: { categories: ['Category1' as unknown as Category] }
+    };
+
+    const mockData = createMockData([
+      { name: '.asyncapi-tool-z', repoName: 'z-tool' },
+      { name: '.asyncapi-tool-a', repoName: 'a-tool' },
+      { name: '.asyncapi-tool-m', repoName: 'm-tool' }
+    ]);
+
+    axiosMock.get
+      .mockResolvedValueOnce({ data: toolContentZ })
+      .mockResolvedValueOnce({ data: toolContentA })
+      .mockResolvedValueOnce({ data: toolContentM });
+
+    const result = await convertTools(mockData);
+
+    expect(result.Category1.toolsList).toHaveLength(3);
+    expect(result.Category1.toolsList[0].title).toBe('A Tool');
+    expect(result.Category1.toolsList[1].title).toBe('M Tool');
+    expect(result.Category1.toolsList[2].title).toBe('Z Tool');
   });
 });


### PR DESCRIPTION
This PR addresses issue #5341 by eliminating non-deterministic behavior in the tools build workflow. When the same set of tools is processed, the output JSON files should always be identical regardless of run order, network timing, or API response ordering.

**Sources of non-determinism fixed:**

1. **GitHub Code Search API ordering (extract-tools-github.ts):** The GitHub search API returns results in non-deterministic order across calls. Items are now sorted by `repository.full_name` (with path as secondary sort key) after aggregation.

2. **Concurrent Promise.all resolution (tools-object.ts):** Tools within each category are processed concurrently via `Promise.all`, so their resolution order varies between runs. Each category's `toolsList` is now sorted by tool title after all promises resolve.

3. **Tag append order (combine-tools.ts):** New language/technology tags discovered during processing are appended in encounter order, which varies when tools are processed concurrently. The language and technology arrays are now sorted by tag name before being written to the output file.

**Changes included:**
- `scripts/tools/extract-tools-github.ts`: Sort GitHub API results by repo full_name
- `scripts/tools/tools-object.ts`: Sort each category's toolsList by title after concurrent processing
- `scripts/tools/combine-tools.ts`: Sort language and technology tags alphabetically before writing
- `tests/build-tools.test.ts`: Added test verifying sorted tags output
- `tests/fixtures/buildToolsData.ts`: Updated fixture to match sorted tag order
- `tests/fixtures/combineToolsData.ts`: Updated fixture to match sorted tag order

Closes #5341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool, language, and technology lists are now deterministically sorted (alphabetical) so generated tags and tool lists are consistent across builds.
  * Data pulled from external sources is returned in a stable, deterministic order.

* **Tests**
  * New tests verify sorted output for tags and tool lists to prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5394)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->