### PR TITLE
fix: handle API rate limit exhaustion in dashboard generation

### DIFF
--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -11,7 +11,7 @@ import type {
   IssueById,
   MappedIssue,
   ProcessedDiscussion,
-  PullRequestById
+  PullRequestById,
 } from '@/types/scripts/dashboard';
 
 import { logger } from '../helpers/logger';
@@ -28,12 +28,23 @@ function isRateLimitError(error: unknown): { hit: boolean; message: string } {
   return { hit, message };
 }
 
-async function waitForRateLimitReset(rateLimit: { remaining: number; resetAt: string }): Promise<void> {
+async function waitForRateLimitReset(rateLimit: {
+  remaining: number;
+  resetAt: string;
+}): Promise<void> {
   if (rateLimit.remaining <= 0) {
     const resetAt = new Date(rateLimit.resetAt).getTime();
+
+    if (Number.isNaN(resetAt)) {
+      logger.error(`Invalid resetAt timestamp: ${rateLimit.resetAt}`);
+      throw new Error(`Invalid resetAt timestamp: ${rateLimit.resetAt}`);
+    }
+
     const waitMs = Math.max(resetAt - Date.now(), 0) + 1000;
 
-    logger.warn(`Rate limit exhausted. Waiting ${Math.ceil(waitMs / 1000)}s until reset...`);
+    logger.warn(
+      `Rate limit exhausted. Waiting ${Math.ceil(waitMs / 1000)}s until reset...`,
+    );
     await pause(waitMs);
   }
 }
@@ -50,7 +61,9 @@ const currentDirPath = dirname(currentFilePath);
  * @returns The number of full months that have elapsed since the specified date.
  */
 function monthsSince(date: string): number {
-  const seconds = Math.floor((new Date().valueOf() - new Date(date).valueOf()) / 1000);
+  const seconds = Math.floor(
+    (new Date().valueOf() - new Date(date).valueOf()) / 1000,
+  );
   // 2592000 = number of seconds in a month = 30 * 24 * 60 * 60
   const months = seconds / 2592000;
 
@@ -69,7 +82,9 @@ function monthsSince(date: string): number {
  * @returns The substring following "/" in the label name if a match is found; otherwise, undefined.
  */
 function getLabel(issue: GoodFirstIssues, filter: string): string | undefined {
-  const result = issue.labels?.nodes?.find((label) => label.name.startsWith(filter));
+  const result = issue.labels?.nodes?.find((label) =>
+    label.name.startsWith(filter),
+  );
 
   return result?.name.split('/')[1];
 }
@@ -90,7 +105,7 @@ async function getDiscussions(
   query: string,
   pageSize: number,
   endCursor: null | string = null,
-  attempt: number = 0
+  attempt: number = 0,
 ): Promise<Discussion['search']['nodes']> {
   const token = process.env.GITHUB_TOKEN;
 
@@ -102,8 +117,8 @@ async function getDiscussions(
       first: pageSize,
       after: endCursor,
       headers: {
-        authorization: `token ${process.env.GITHUB_TOKEN}`
-      }
+        authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
     });
 
     if (result.rateLimit.remaining <= 100) {
@@ -112,7 +127,7 @@ async function getDiscussions(
           `cost = ${result.rateLimit.cost}\n` +
           `limit = ${result.rateLimit.limit}\n` +
           `remaining = ${result.rateLimit.remaining}\n` +
-          `resetAt = ${result.rateLimit.resetAt}`
+          `resetAt = ${result.rateLimit.resetAt}`,
       );
     }
 
@@ -129,12 +144,16 @@ async function getDiscussions(
       return result.search.nodes;
     }
 
-    return result.search.nodes.concat(await getDiscussions(query, pageSize, result.search.pageInfo.endCursor));
+    return result.search.nodes.concat(
+      await getDiscussions(query, pageSize, result.search.pageInfo.endCursor),
+    );
   } catch (error: unknown) {
     const { hit, message } = isRateLimitError(error);
 
     if (hit && attempt < RATE_LIMIT_MAX_RETRIES) {
-      logger.warn(`Rate limit hit (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`);
+      logger.warn(
+        `Rate limit hit (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`,
+      );
       await pause(RATE_LIMIT_BACKOFF_MS);
 
       return getDiscussions(query, pageSize, endCursor, attempt + 1);
@@ -156,7 +175,11 @@ async function getDiscussions(
  *
  * @throws {Error} If the GraphQL request fails.
  */
-async function getDiscussionByID(isPR: boolean, id: string, attempt: number = 0): Promise<PullRequestById | IssueById> {
+async function getDiscussionByID(
+  isPR: boolean,
+  id: string,
+  attempt: number = 0,
+): Promise<PullRequestById | IssueById> {
   const token = process.env.GITHUB_TOKEN;
 
   if (!token) {
@@ -164,19 +187,24 @@ async function getDiscussionByID(isPR: boolean, id: string, attempt: number = 0)
   }
 
   try {
-    const result: PullRequestById | IssueById = await graphql(isPR ? Queries.pullRequestById : Queries.issueById, {
-      id,
-      headers: {
-        authorization: `token ${token}`
-      }
-    });
+    const result: PullRequestById | IssueById = await graphql(
+      isPR ? Queries.pullRequestById : Queries.issueById,
+      {
+        id,
+        headers: {
+          authorization: `token ${token}`,
+        },
+      },
+    );
 
     return result;
   } catch (error: unknown) {
     const { hit, message } = isRateLimitError(error);
 
     if (hit && attempt < RATE_LIMIT_MAX_RETRIES) {
-      logger.warn(`Rate limit hit in getDiscussionByID (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`);
+      logger.warn(
+        `Rate limit hit in getDiscussionByID (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`,
+      );
       await pause(RATE_LIMIT_BACKOFF_MS);
 
       return getDiscussionByID(isPR, id, attempt + 1);
@@ -199,7 +227,9 @@ async function getDiscussionByID(isPR: boolean, id: string, attempt: number = 0)
  *
  * @throws {Error} When processing a discussion fails.
  */
-async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise<ProcessedDiscussion[]> {
+async function processHotDiscussions(
+  batch: HotDiscussionsIssuesNode[],
+): Promise<ProcessedDiscussion[]> {
   return Promise.all(
     batch.map(async (discussion) => {
       try {
@@ -207,7 +237,10 @@ async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise
         const isPR = discussion.__typename === 'PullRequest';
 
         if (discussion.comments.pageInfo?.hasNextPage) {
-          const fetchedDiscussion = await getDiscussionByID(isPR, discussion.id);
+          const fetchedDiscussion = await getDiscussionByID(
+            isPR,
+            discussion.id,
+          );
 
           // eslint-disable-next-line no-param-reassign
           discussion = fetchedDiscussion.node;
@@ -216,12 +249,18 @@ async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise
         const interactionsCount =
           discussion.reactions.totalCount +
           discussion.comments.totalCount +
-          discussion.comments.nodes.reduce((acc, curr) => acc + curr.reactions.totalCount, 0);
+          discussion.comments.nodes.reduce(
+            (acc, curr) => acc + curr.reactions.totalCount,
+            0,
+          );
 
         const finalInteractionsCount = isPR
           ? interactionsCount +
             discussion.reviews.totalCount +
-            (discussion.reviews.nodes?.reduce((acc, curr) => acc + curr.comments.totalCount, 0) ?? 0)
+            (discussion.reviews.nodes?.reduce(
+              (acc, curr) => acc + curr.comments.totalCount,
+              0,
+            ) ?? 0)
           : interactionsCount;
 
         return {
@@ -233,13 +272,17 @@ async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise
           resourcePath: discussion.resourcePath,
           repo: `asyncapi/${discussion.repository.name}`,
           labels: discussion.labels ? discussion.labels.nodes : [],
-          score: finalInteractionsCount / (monthsSince(discussion.timelineItems.updatedAt) + 2) ** 1.8
+          score:
+            finalInteractionsCount /
+            (monthsSince(discussion.timelineItems.updatedAt) + 2) ** 1.8,
         };
       } catch (error) {
-        logger.error(`there were some issues while parsing this item: ${JSON.stringify(discussion)}`);
+        logger.error(
+          `there were some issues while parsing this item: ${JSON.stringify(discussion)}`,
+        );
         throw error;
       }
-    })
+    }),
   );
 }
 
@@ -253,7 +296,9 @@ async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise
  * @param discussions - The array of discussion nodes to process.
  * @returns A promise that resolves to an array of up to 12 processed hot discussions.
  */
-async function getHotDiscussions(discussions: HotDiscussionsIssuesNode[]): Promise<ProcessedDiscussion[]> {
+async function getHotDiscussions(
+  discussions: HotDiscussionsIssuesNode[],
+): Promise<ProcessedDiscussion[]> {
   const result: ProcessedDiscussion[] = [];
   const batchSize = 5;
 
@@ -268,7 +313,9 @@ async function getHotDiscussions(discussions: HotDiscussionsIssuesNode[]): Promi
   }
 
   result.sort((ElemA, ElemB) => ElemB.score - ElemA.score);
-  const filteredResult = result.filter((issue) => issue.author !== 'asyncapi-bot');
+  const filteredResult = result.filter(
+    (issue) => issue.author !== 'asyncapi-bot',
+  );
 
   return filteredResult.slice(0, 12);
 }
@@ -288,14 +335,14 @@ async function writeToFile(
     hotDiscussions: ProcessedDiscussion[];
     goodFirstIssues: MappedIssue[];
   },
-  writePath: string
+  writePath: string,
 ): Promise<void> {
   try {
     await writeFile(writePath, JSON.stringify(content, null, '  '));
   } catch (error) {
     logger.error('Failed to write dashboard data:', {
       error: (error as Error).message,
-      writePath
+      writePath,
     });
     throw error;
   }
@@ -311,7 +358,9 @@ async function writeToFile(
  * @param issues - The list of good first issues to transform.
  * @returns A promise that resolves to an array of simplified issue objects.
  */
-async function mapGoodFirstIssues(issues: GoodFirstIssues[]): Promise<MappedIssue[]> {
+async function mapGoodFirstIssues(
+  issues: GoodFirstIssues[],
+): Promise<MappedIssue[]> {
   return issues.map((issue) => ({
     id: issue.id,
     title: issue.title,
@@ -321,8 +370,10 @@ async function mapGoodFirstIssues(issues: GoodFirstIssues[]): Promise<MappedIssu
     author: issue.author.login,
     area: getLabel(issue, 'area/') || 'Unknown',
     labels: issue.labels!.nodes.filter(
-      (label) => !label.name.startsWith('area/') && !label.name.startsWith('good first issue')
-    )
+      (label) =>
+        !label.name.startsWith('area/') &&
+        !label.name.startsWith('good first issue'),
+    ),
   }));
 }
 
@@ -339,13 +390,22 @@ async function mapGoodFirstIssues(issues: GoodFirstIssues[]): Promise<MappedIssu
  */
 async function start(writePath: string): Promise<void> {
   try {
-    const issues = (await getDiscussions(Queries.hotDiscussionsIssues, 20)) as HotDiscussionsIssuesNode[];
-    const PRs = (await getDiscussions(Queries.hotDiscussionsPullRequests, 20)) as HotDiscussionsPullRequestsNode[];
-    const rawGoodFirstIssues: GoodFirstIssues[] = await getDiscussions(Queries.goodFirstIssues, 20);
+    const issues = (await getDiscussions(
+      Queries.hotDiscussionsIssues,
+      20,
+    )) as HotDiscussionsIssuesNode[];
+    const PRs = (await getDiscussions(
+      Queries.hotDiscussionsPullRequests,
+      20,
+    )) as HotDiscussionsPullRequestsNode[];
+    const rawGoodFirstIssues: GoodFirstIssues[] = await getDiscussions(
+      Queries.goodFirstIssues,
+      20,
+    );
     const discussions = issues.concat(PRs);
     const [hotDiscussions, goodFirstIssues] = await Promise.all([
       getHotDiscussions(discussions),
-      mapGoodFirstIssues(rawGoodFirstIssues)
+      mapGoodFirstIssues(rawGoodFirstIssues),
     ]);
 
     await writeToFile({ hotDiscussions, goodFirstIssues }, writePath);
@@ -368,5 +428,5 @@ export {
   mapGoodFirstIssues,
   processHotDiscussions,
   start,
-  writeToFile
+  writeToFile,
 };

--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -18,6 +18,26 @@ import { logger } from '../helpers/logger';
 import { pause } from '../helpers/utils';
 import { Queries } from './issue-queries';
 
+const RATE_LIMIT_MAX_RETRIES = 5;
+const RATE_LIMIT_BACKOFF_MS = 60_000;
+
+function isRateLimitError(error: unknown): { hit: boolean; message: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const hit = /rate limit|secondary rate/i.test(message);
+
+  return { hit, message };
+}
+
+async function waitForRateLimitReset(rateLimit: { remaining: number; resetAt: string }): Promise<void> {
+  if (rateLimit.remaining <= 0) {
+    const resetAt = new Date(rateLimit.resetAt).getTime();
+    const waitMs = Math.max(resetAt - Date.now(), 0) + 1000;
+
+    logger.warn(`Rate limit exhausted. Waiting ${Math.ceil(waitMs / 1000)}s until reset...`);
+    await pause(waitMs);
+  }
+}
+
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = dirname(currentFilePath);
 
@@ -69,7 +89,8 @@ function getLabel(issue: GoodFirstIssues, filter: string): string | undefined {
 async function getDiscussions(
   query: string,
   pageSize: number,
-  endCursor: null | string = null
+  endCursor: null | string = null,
+  attempt: number = 0
 ): Promise<Discussion['search']['nodes']> {
   const token = process.env.GITHUB_TOKEN;
 
@@ -95,6 +116,11 @@ async function getDiscussions(
       );
     }
 
+    // Wait for rate limit reset if exhausted
+    if (result.rateLimit.remaining <= 0) {
+      await waitForRateLimitReset(result.rateLimit);
+    }
+
     await pause(500);
 
     const { hasNextPage } = result.search.pageInfo;
@@ -104,7 +130,16 @@ async function getDiscussions(
     }
 
     return result.search.nodes.concat(await getDiscussions(query, pageSize, result.search.pageInfo.endCursor));
-  } catch (error) {
+  } catch (error: unknown) {
+    const { hit, message } = isRateLimitError(error);
+
+    if (hit && attempt < RATE_LIMIT_MAX_RETRIES) {
+      logger.warn(`Rate limit hit (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`);
+      await pause(RATE_LIMIT_BACKOFF_MS);
+
+      return getDiscussions(query, pageSize, endCursor, attempt + 1);
+    }
+
     logger.error(error);
     throw error;
   }
@@ -121,7 +156,7 @@ async function getDiscussions(
  *
  * @throws {Error} If the GraphQL request fails.
  */
-async function getDiscussionByID(isPR: boolean, id: string): Promise<PullRequestById | IssueById> {
+async function getDiscussionByID(isPR: boolean, id: string, attempt: number = 0): Promise<PullRequestById | IssueById> {
   const token = process.env.GITHUB_TOKEN;
 
   if (!token) {
@@ -137,7 +172,16 @@ async function getDiscussionByID(isPR: boolean, id: string): Promise<PullRequest
     });
 
     return result;
-  } catch (error) {
+  } catch (error: unknown) {
+    const { hit, message } = isRateLimitError(error);
+
+    if (hit && attempt < RATE_LIMIT_MAX_RETRIES) {
+      logger.warn(`Rate limit hit in getDiscussionByID (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES}), waiting 60s: ${message}`);
+      await pause(RATE_LIMIT_BACKOFF_MS);
+
+      return getDiscussionByID(isPR, id, attempt + 1);
+    }
+
     logger.error(error);
     throw error;
   }

--- a/tests/dashboard/build-dashboard.test.ts
+++ b/tests/dashboard/build-dashboard.test.ts
@@ -3,7 +3,10 @@ import { mkdirSync, promises as fs, rmSync } from 'fs-extra';
 import os from 'os';
 import { resolve } from 'path';
 
-import type { GoodFirstIssues, HotDiscussionsIssuesNode } from '@/types/scripts/dashboard';
+import type {
+  GoodFirstIssues,
+  HotDiscussionsIssuesNode,
+} from '@/types/scripts/dashboard';
 
 import {
   getDiscussionByID,
@@ -12,7 +15,7 @@ import {
   getLabel,
   mapGoodFirstIssues,
   start,
-  writeToFile
+  writeToFile,
 } from '../../scripts/dashboard/build-dashboard';
 import { logger } from '../../scripts/helpers/logger';
 import {
@@ -20,11 +23,15 @@ import {
   fullDiscussionDetails,
   issues,
   mockDiscussion,
-  mockRateLimitResponse
+  mockRateLimitResponse,
 } from '../fixtures/dashboardData';
 
 jest.mock('../../scripts/helpers/logger', () => ({
-  logger: { error: jest.fn(), warn: jest.fn() }
+  logger: { error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('../../scripts/helpers/utils', () => ({
+  pause: jest.fn(),
 }));
 
 jest.mock('@octokit/graphql', () => ({
@@ -68,14 +75,14 @@ describe('GitHub Discussions Processing', () => {
       expect.any(String),
       expect.objectContaining({
         id: 'paginated-discussion',
-        headers: expect.any(Object)
-      })
+        headers: expect.any(Object),
+      }),
     );
 
     expect(result[0]).toMatchObject({
       id: 'paginated-discussion',
       isPR: false,
-      title: 'Test with Pagination'
+      title: 'Test with Pagination',
     });
 
     const firstResult = result[0];
@@ -89,7 +96,58 @@ describe('GitHub Discussions Processing', () => {
     await getDiscussions('test-query', 10);
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('GitHub GraphQL rateLimit \ncost = 1\nlimit = 5000\nremaining = 50')
+      expect.stringContaining(
+        'GitHub GraphQL rateLimit \ncost = 1\nlimit = 5000\nremaining = 50',
+      ),
+    );
+  });
+
+  it('should reject invalid resetAt timestamps', async () => {
+    mockedGraphql.mockResolvedValueOnce({
+      ...mockRateLimitResponse,
+      rateLimit: {
+        ...mockRateLimitResponse.rateLimit,
+        remaining: 0,
+        resetAt: 'invalid-date',
+      },
+    });
+
+    await expect(getDiscussions('test-query', 10)).rejects.toThrow(
+      'Invalid resetAt timestamp: invalid-date',
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'Invalid resetAt timestamp: invalid-date',
+    );
+  });
+
+  it('should wait when the rate limit is exhausted', async () => {
+    mockedGraphql.mockResolvedValueOnce({
+      ...mockRateLimitResponse,
+      rateLimit: {
+        ...mockRateLimitResponse.rateLimit,
+        remaining: 0,
+        resetAt: new Date(Date.now() - 1000).toISOString(),
+      },
+    });
+
+    await getDiscussions('test-query', 10);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Rate limit exhausted. Waiting'),
+    );
+  });
+
+  it('should retry getDiscussions when GitHub returns a rate limit error', async () => {
+    mockedGraphql
+      .mockRejectedValueOnce(new Error('rate limit exceeded'))
+      .mockResolvedValueOnce(mockRateLimitResponse);
+
+    const result = await getDiscussions('test-query', 10);
+
+    expect(result).toEqual(mockRateLimitResponse.search.nodes);
+    expect(mockedGraphql).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Rate limit hit (attempt 1/5)'),
     );
   });
 
@@ -97,20 +155,22 @@ describe('GitHub Discussions Processing', () => {
     const mockFirstResponse = {
       search: {
         nodes: [mockDiscussion],
-        pageInfo: { hasNextPage: true, endCursor: 'cursor1' }
+        pageInfo: { hasNextPage: true, endCursor: 'cursor1' },
       },
-      rateLimit: { remaining: 1000 }
+      rateLimit: { remaining: 1000 },
     };
 
     const mockSecondResponse = {
       search: {
         nodes: [{ ...mockDiscussion, id: 'test-id-2' }],
-        pageInfo: { hasNextPage: false }
+        pageInfo: { hasNextPage: false },
       },
-      rateLimit: { remaining: 1000 }
+      rateLimit: { remaining: 1000 },
     };
 
-    mockedGraphql.mockResolvedValueOnce(mockFirstResponse).mockResolvedValueOnce(mockSecondResponse);
+    mockedGraphql
+      .mockResolvedValueOnce(mockFirstResponse)
+      .mockResolvedValueOnce(mockSecondResponse);
 
     const result = await getDiscussions('test-query', 10);
 
@@ -123,7 +183,9 @@ describe('GitHub Discussions Processing', () => {
     const filePath = resolve(tempDir, 'error-output.json');
 
     await start(filePath);
-    expect(logger.error).toHaveBeenCalledWith('There were some issues parsing data from github.');
+    expect(logger.error).toHaveBeenCalledWith(
+      'There were some issues parsing data from github.',
+    );
   });
 
   it('should successfully process and write data', async () => {
@@ -141,7 +203,7 @@ describe('GitHub Discussions Processing', () => {
 
   it('should get labels correctly', () => {
     const issue = {
-      labels: { nodes: [{ name: 'area/bug' }, { name: 'good first issue' }] }
+      labels: { nodes: [{ name: 'area/bug' }, { name: 'good first issue' }] },
     } as GoodFirstIssues;
 
     expect(getLabel(issue, 'area/')).toBe('bug');
@@ -153,7 +215,7 @@ describe('GitHub Discussions Processing', () => {
 
     expect(result[0]).toMatchObject({
       id: '1',
-      area: 'docs'
+      area: 'docs',
     });
   });
 
@@ -170,9 +232,9 @@ describe('GitHub Discussions Processing', () => {
         nodes: [
           { name: 'area/documentation', color: '#0366d6' },
           { name: 'good first issue', color: '#7057ff' },
-          { name: 'bug', color: '#d73a4a' }
-        ]
-      }
+          { name: 'bug', color: '#d73a4a' },
+        ],
+      },
     };
 
     const result = await mapGoodFirstIssues([mockIssue]);
@@ -186,7 +248,7 @@ describe('GitHub Discussions Processing', () => {
       repo: 'asyncapi/test-repo',
       author: 'testuser',
       area: 'documentation',
-      labels: [{ name: 'bug', color: '#d73a4a' }]
+      labels: [{ name: 'bug', color: '#d73a4a' }],
     });
   });
 
@@ -200,14 +262,35 @@ describe('GitHub Discussions Processing', () => {
     await expect(getDiscussionByID(true, 'test-id')).rejects.toThrow();
   });
 
+  it('should retry getDiscussionByID when GitHub returns a secondary rate limit error', async () => {
+    mockedGraphql
+      .mockRejectedValueOnce(new Error('secondary rate limit'))
+      .mockResolvedValueOnce({ node: mockDiscussion });
+
+    const result = await getDiscussionByID(false, 'test-id');
+
+    expect(result.node).toBe(mockDiscussion);
+    expect(mockedGraphql).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Rate limit hit in getDiscussionByID (attempt 1/5)',
+      ),
+    );
+  });
+
   it('should process hot discussions', async () => {
     const prDiscussion = {
       ...mockDiscussion,
       __typename: 'PullRequest',
       reviews: {
         totalCount: 1,
-        nodes: [{ lastEditedAt: new Date().toISOString(), comments: { totalCount: 1 } }]
-      }
+        nodes: [
+          {
+            lastEditedAt: new Date().toISOString(),
+            comments: { totalCount: 1 },
+          },
+        ],
+      },
     } as HotDiscussionsIssuesNode;
 
     const result = await getHotDiscussions([mockDiscussion, prDiscussion]);
@@ -221,8 +304,8 @@ describe('GitHub Discussions Processing', () => {
       __typename: 'PullRequest',
       reviews: {
         totalCount: 1,
-        nodes: undefined // This will trigger the ?? 0 part
-      }
+        nodes: undefined, // This will trigger the ?? 0 part
+      },
     };
 
     const result = await getHotDiscussions([prDiscussion]);
@@ -234,7 +317,7 @@ describe('GitHub Discussions Processing', () => {
     const prDiscussion = {
       ...mockDiscussion,
       __typename: 'PullRequest',
-      labels: null // This will trigger the ?? [] part
+      labels: null, // This will trigger the ?? [] part
     };
 
     const result = await getHotDiscussions([prDiscussion]);
@@ -256,7 +339,9 @@ describe('GitHub Discussions Processing', () => {
 
     await expect(getHotDiscussions([undefined] as any)).rejects.toThrow();
 
-    expect(logger.error).toHaveBeenCalledWith('there were some issues while parsing this item: undefined');
+    expect(logger.error).toHaveBeenCalledWith(
+      'there were some issues while parsing this item: undefined',
+    );
 
     localConsoleErrorSpy.mockRestore();
   });
@@ -271,9 +356,13 @@ describe('GitHub Discussions Processing', () => {
 
     // getDiscussionsById and getDiscussions
     // @ts-expect-error - Intentionally calling without arguments to test missing token error
-    await expect(getDiscussionByID()).rejects.toThrow('GitHub token is not set in environment variables');
+    await expect(getDiscussionByID()).rejects.toThrow(
+      'GitHub token is not set in environment variables',
+    );
     // @ts-expect-error - Intentionally calling without arguments to test missing token error
-    await expect(getDiscussions()).rejects.toThrow('GitHub token is not set in environment variables');
+    await expect(getDiscussions()).rejects.toThrow(
+      'GitHub token is not set in environment variables',
+    );
 
     process.env.GITHUB_TOKEN = 'test-token';
   });
@@ -282,13 +371,17 @@ describe('GitHub Discussions Processing', () => {
     // Create two identical discussions but with different update timestamps
     const recentDiscussion = {
       ...mockDiscussion,
-      timelineItems: { updatedAt: new Date().toISOString() }
+      timelineItems: { updatedAt: new Date().toISOString() },
     };
 
     const olderDiscussion = {
       ...mockDiscussion,
       id: 'older-discussion',
-      timelineItems: { updatedAt: new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000).toISOString() } // 6 months ago
+      timelineItems: {
+        updatedAt: new Date(
+          Date.now() - 6 * 30 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      }, // 6 months ago
     };
 
     const result = await getHotDiscussions([recentDiscussion, olderDiscussion]);


### PR DESCRIPTION
## Problem

The dashboard page shows outdated data because `npm run generate:dashboard` fails silently when GitHub API rate limits are exhausted during data collection.

The workflow runs successfully and opens PRs, but dashboard.json is not updated because the script throws on rate limit errors.

## Fix

- Wait for rate limit reset when `remaining` hits 0 (uses `resetAt` timestamp from API response)
- Retry on rate limit errors (HTTP 403 with "rate limit" message) after 60s delay
- Apply same retry logic to both `getDiscussions()` and `getDiscussionByID()`

## How it works

1. After each API call, check if `remaining <= 0`
2. If exhausted, calculate wait time from `resetAt` and sleep
3. On catch, if error message contains "rate limit", wait 60s and retry
4. Otherwise, throw as before

Fixes #5333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard build now detects API rate limits (including secondary limits), automatically retries with bounded backoff (up to 5 attempts), and waits until the service reset time (+1s) to avoid build failures.
  * Added clearer logging during rate-limit waits so issues are visible without manual restarts.

* **Tests**
  * Improved test coverage and added a negative-path test for invalid rate-limit reset timestamps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5403)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->