### PR TITLE
fix: prevent silent failure in dashboard.json regeneration (fixes #5333)

### DIFF
--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -308,6 +308,9 @@ async function start(writePath: string): Promise<void> {
   } catch (error) {
     logger.error('There were some issues parsing data from github.');
     logger.error(error);
+    // Re-throw so the workflow step fails and alerts the team
+    // instead of silently skipping dashboard.json generation.
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Fixes #5333

### Problem
The dashboard.json file stopped updating because build-dashboard.ts silently catches all errors in its start() function. When GitHub GraphQL API rate limits are hit or other errors occur, the function logs the error but doesn't re-throw. The workflow step passes, the PR is created with meetings/videos data only, and dashboard.json stays stale (last updated 2025-04-28).

### Fix
Re-throw the error in the start() function's catch block so the workflow step fails and the team is alerted via the existing Slack notification.

### Changes
- scripts/dashboard/build-dashboard.ts: throw error in start() catch block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Dashboard build failures are now properly reported instead of being silently overlooked, ensuring errors in data generation are clearly flagged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->