### PR TITLE
fix(docs): wire correct icons to docs landing cards (Closes #5699)

### DIFF
--- a/components/data/buckets.ts
+++ b/components/data/buckets.ts
@@ -1,12 +1,12 @@
 import type React from 'react';
 
-import IconExplorer from '../icons/Explorer';
 import IconGettingStarted from '../icons/GettingStarted';
+import IconLoupe from '../icons/Loupe';
 import IconGuide from '../icons/Guide';
 import IconMigration from '../icons/Migration';
 import IconSpec from '../icons/Spec';
 import IconTutorials from '../icons/Tutorials';
-import IconUseCases from '../icons/UseCases';
+import IconTools from '../icons/Tools';
 import IconUsers from '../icons/Users';
 
 export interface Bucket {
@@ -59,7 +59,7 @@ export const buckets: Bucket[] = [
     className: 'bg-primary-100 dark:bg-primary-500/20 border border-primary-500 text-primary-600 dark:text-primary-300',
     borderClassName: 'border-green-200',
     href: '/docs/tools',
-    icon: IconUseCases
+    icon: IconTools
   },
   {
     name: 'reference',
@@ -98,7 +98,7 @@ export const buckets: Bucket[] = [
     link: '/docs/reference/specification/v3.0.0-explorer',
     className: 'bg-primary-100 dark:bg-primary-500/20 border border-primary-500 text-primary-600 dark:text-primary-300',
     borderClassName: 'border-primary-200',
-    icon: IconExplorer
+    icon: IconLoupe
   }
 ].map((bucket) => {
   return {

--- a/components/icons/Migration.tsx
+++ b/components/icons/Migration.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 /**
  * @description Icons for asyncapi website
  */
-export default function IconUsers({ ...rest }) {
+export default function IconMigration({ ...rest }) {
   // <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
   return (
     <svg


### PR DESCRIPTION
## Summary

Fixes #5699 — Docs / Community card icons in the landing page Header section use icons that don't match their sections.

### Changes

1. **`components/data/buckets.ts`**
   - **Tools** bucket: was using `IconUseCases` (pen/quill — reads as "writing/authoring") → now uses `IconTools` (wrench/tools metaphor matching the AsyncAPI tools ecosystem docs).
   - **Specification Explorer** bucket: was using `IconExplorer` (sitemap node with plus sign — reads as "add a node") → now uses `IconLoupe` (magnifier, matching the "explore the spec" intent).
   - Removed the now-unused `IconExplorer` import.

2. **`components/icons/Migration.tsx`**
   - The component exported itself as `IconUsers` while living in `Migration.tsx`, which misleads any consumer importing it as `IconMigration` and shadows the real `Users` icon's role. Renamed the export to `IconMigration` to match the file name and its actual migration icon content.

### Verification

- `components/icons/Tools.tsx` and `components/icons/Loupe.tsx` already existed (verified via repo tree) — no new icons needed to be authored.
- `buckets.ts` import list now includes `IconTools` and `IconLoupe`, and no longer references `IconExplorer`/`IconUseCases` in the card mappings.
- The real `Users` icon (`components/icons/Users.tsx`) still exports `IconUsers` and is untouched — Community card remains correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated category icons to better represent Tools and Explorer.
  * Corrected the migration icon’s label while preserving its appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->